### PR TITLE
Change location of generated OpenAPI sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             </goals>
             <configuration>
               <inputSpec>${tenant.yaml.file}</inputSpec>
-              <output>${project.build.directory}/generated-sources</output>
+              <output>${project.build.directory}/generated-sources/openapi-generator</output>
               <generatorName>java-vertx-web</generatorName>
               <modelPackage>${project.groupId}.tenant.main</modelPackage>
               <apiPackage>${project.groupId}.tenant.rest.resource</apiPackage>


### PR DESCRIPTION
Otherwise vscode complains about undefined symbols, see https://github.com/redhat-developer/vscode-java/issues/177#issuecomment-623525778