### PR TITLE
Add boolen `ignoreTitle` field to reportTitle.json

### DIFF
--- a/src/main/resources/openapi/schemas/reportTitle.json
+++ b/src/main/resources/openapi/schemas/reportTitle.json
@@ -18,6 +18,10 @@
       "type": "string",
       "description": "KB title identifier"
     },
+    "ignoreTitle": {
+      "type": "boolean",
+      "description": "whether the title should simply be ignored [default: false]"
+    },
     "kbManualMatch": {
       "type": "boolean",
       "description": "whether the counter title to kb title is manual"


### PR DESCRIPTION
When manually matching titles, one option is to mark a title as ignored, so that it does not contribute to usage statistics. (You can see this in Kristen's UI mockups.)

I added a boolean `ignoreTitle` field as the place to store this status.

Does this make sense to you, @adamdickmeiss @skoczko?