### PR TITLE
Exclude parameters dir from api-lint and api-doc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ buildMvn {
   doApiDoc = true
   apiTypes = 'OAS'
   apiDirectories = 'src/main/resources/openapi'
-  apiExcludes = 'headers'
+  apiExcludes = 'headers parameters'
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Until this new directory can be excluded via the tools