### PR TITLE
MODEUR-14: Use over time report by year

### DIFF
--- a/src/main/resources/openapi/parameters/end-date.yaml
+++ b/src/main/resources/openapi/parameters/end-date.yaml
@@ -1,7 +1,9 @@
 in: query
 name: endDate
-description: end date, RFC3339, section 5.6, for example 2017-07-21
+description: last year for year reporting, or last month for month reporting
 required: true
 schema:
-  type: string
-  format: date
+   type: string
+   pattern: ^[12]\d\d\d(-0[1-9]|-1[012])?$
+   description: A year in range 1000-2999, or a year in range 1000-2999 and a minus and a month in range 01-12 (similar to RFC3339, section 5.6).
+   example: 2019-04

--- a/src/main/resources/openapi/parameters/start-date.yaml
+++ b/src/main/resources/openapi/parameters/start-date.yaml
@@ -1,8 +1,9 @@
 in: query
 name: startDate
-description: start date, RFC3339, section 5.6, for example 2017-07-21
-
+description: last year for year reporting, or last month for month reporting
 required: true
 schema:
-  type: string
-  format: date
+   type: string
+   pattern: ^[12]\d\d\d(-0[1-9]|-1[012])?$
+   description: A year in range 1000-2999, or a year in range 1000-2999 and a minus and a month in range 01-12 (similar to RFC3339, section 5.6).
+   example: 2019-04

--- a/src/test/java/org/folio/tlib/api/ApiIT.java
+++ b/src/test/java/org/folio/tlib/api/ApiIT.java
@@ -112,8 +112,8 @@ public class ApiIT {
 
     given().
       param("agreementId", "10000000-0000-4000-8000-000000000000").
-      param("startDate", "2020-03-01").
-      param("endDate", "2020-05-01").
+      param("startDate", "2020-03").
+      param("endDate", "2020-04").
       param("format", "JOURNAL").
     when().
       get("/eusage-reports/stored-reports/use-over-time").


### PR DESCRIPTION
The end month or end year is inclusive.

Internally an end day is calculated, this end day
is exclusive because it is easier to implement and
matches PostgreSQL's default.