### PR TITLE
application_name for pg_stat_activity

### DIFF
--- a/src/main/java/org/folio/tlib/postgres/impl/TenantPgPoolImpl.java
+++ b/src/main/java/org/folio/tlib/postgres/impl/TenantPgPoolImpl.java
@@ -98,6 +98,9 @@ public class TenantPgPoolImpl implements TenantPgPool {
       throw new IllegalStateException("TenantPgPool.setModule must be called");
     }
     PgConnectOptions connectOptions = pgConnectOptions;
+    // overwrite default "vertx-pg-client" shown in pg_stat_activity
+    // https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME
+    connectOptions.getProperties().put("application_name", module);
     if (host != null) {
       connectOptions.setHost(substTenant(host, tenant));
     }


### PR DESCRIPTION
Show module name as application_name for pg_stat_activity.

Test cleanup in TenantPgPoolTest:

* Remove unused pgConnectOptions variable.
* Always initialize postgresql.conf, not only when testSSL succeeds.
* Extract duplicate code into withPool. This also fixes missing
  pool.close() calls.
* Extend execute2 to test that the SQL after the failure doesn't run.