### PR TITLE
MODEUR-49: MainVerticleTest, Tenant2ApiTest, ApiIT ordering

### DIFF
--- a/src/test/java/org/folio/eusage/reports/MainVerticleTest.java
+++ b/src/test/java/org/folio/eusage/reports/MainVerticleTest.java
@@ -1,6 +1,7 @@
 package org.folio.eusage.reports;
 
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
@@ -638,7 +639,8 @@ public class MainVerticleTest {
   public static void beforeClass(TestContext context) {
     vertx = Vertx.vertx();
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-    RestAssured.port = MODULE_PORT;
+    RestAssured.baseURI = "http://localhost:" + MODULE_PORT;
+    RestAssured.requestSpecification = new RequestSpecBuilder().build();
 
     Router router = Router.router(vertx);
     router.getWithRegex("/counter-reports").handler(MainVerticleTest::getCounterReports);

--- a/src/test/java/org/folio/tlib/api/Tenant2ApiTest.java
+++ b/src/test/java/org/folio/tlib/api/Tenant2ApiTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.vertx.core.Future;
@@ -88,7 +89,9 @@ public class Tenant2ApiTest {
     TenantPgPool.setModule("mod-tenant");
     vertx = Vertx.vertx();
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-    RestAssured.port = port;
+    RestAssured.baseURI = "http://localhost:" + port;
+    RestAssured.requestSpecification = new RequestSpecBuilder().build();
+
     initialPgConnectOptions = TenantPgPool.getDefaultConnectOptions();
 
     new Tenant2Api(hooks).createRouter(vertx, WebClient.create(vertx))


### PR DESCRIPTION
After ApiIT was added it was no longer possible to run Tenant2ApiTest
and MainVerticleTest without failures in IntelliJ Idea. For details see
https://issues.folio.org/browse/MODEUR-49

Solution: reset RestAssured static initializers.
I don't know why ApiIT was an integration test
to be begin with. After this change, it no longer need to be.
So it could be renamed as well.