### PR TITLE
yopInterval MODEUR-52

### DIFF
--- a/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
+++ b/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
@@ -1221,7 +1221,7 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
         writer.print(item.getString("ISBN"));
       }
       if (groupByPublicationYear) {
-        writer.print(item.getLong("publicationYear"));
+        writer.print(item.getString("publicationYear"));
       }
       if (periodOfUse) {
         writer.print(item.getString("periodOfUse"));
@@ -1475,12 +1475,27 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
     sql.append(" WHERE agreementId = $1::uuid").append(limitJournal(isJournal));
   }
 
+  static String pubPeriodToString(LocalDate date, int periodMonth) {
+    String s1 = date.toString();
+    String s2 = date.plusMonths(periodMonth - 1).toString();
+    if (s1.endsWith("-01-01") && s2.endsWith("-12-01")) {
+      s1 = s1.substring(0, 4);
+      s2 = s2.substring(0, 4);
+    } else {
+      s1 = s1.substring(0, 7);
+      s2 = s2.substring(0, 7);
+    }
+    return s1.equals(s2) ? s1 : s1 + "-" + s2;
+  }
+
   Future<JsonObject> getReqsByDateOfUse(TenantPgPool pool,
                                         Boolean isJournal, boolean includeOA, String agreementId,
-                                        String accessCountPeriod, String start, String end) {
+                                        String accessCountPeriod, String start, String end,
+                                        String yopInterval) {
 
     Periods usePeriods = new Periods(start, end, accessCountPeriod);
-    int pubPeriodsInMonths = 12;
+    int pubPeriodsInMonths = yopInterval == null || "auto".equals(yopInterval)
+        ? 12 : Periods.getPeriodInMonths(yopInterval);
 
     return getPubPeriods(pool, isJournal, agreementId, usePeriods, pubPeriodsInMonths)
         .compose(pubYears -> {
@@ -1534,13 +1549,13 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
               long accessCountTotal = 0L;
               boolean unique = "Unique_Item_Requests".equals(row.getString("metrictype"));
               JsonArray accessCountByPeriod = new JsonArray();
-              int publicationYear = row.getLocalDate("publicationdate").getYear();
+              String publicationPeriod = pubPeriodToString(row.getLocalDate("publicationdate"),
+                  pubPeriodsInMonths);
               for (int i = 0; i < usePeriods.size(); i++) {
                 Long l = row.getLong(columnsToSkip + i);
                 accessCountByPeriod.add(l);
                 if (l != null) {
                   accessCountTotal += l;
-                  String key = Integer.toString(publicationYear);
                   JsonObject d;
                   if (unique) {
                     uniqueItemRequestsByPeriod[i].add(l);
@@ -1549,9 +1564,9 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
                     totalItemRequestsByPeriod[i].add(l);
                     d = totalRequestsPublicationYearsByPeriod.getJsonObject(i);
                   }
-                  Long count = d.getLong(key);
+                  Long count = d.getLong(publicationPeriod);
                   count = count == null ? l : l + count;
-                  d.put(key, count);
+                  d.put(publicationPeriod, count);
                 }
               }
               if (accessCountTotal > 0L) {
@@ -1566,7 +1581,7 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
                   json.put("ISBN", row.getString("isbn"));
                 }
                 json
-                    .put("publicationYear", publicationYear)
+                    .put("publicationYear", publicationPeriod)
                     .put("accessType", row.getString("accesstype"))
                     .put("metricType", row.getString("metrictype"))
                     .put("accessCountTotal", accessCountTotal)
@@ -1591,9 +1606,9 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
 
   Future<String> getReqsByDateOfUse(TenantPgPool pool, Boolean isJournal, boolean includeOA,
                                     String agreementId, String accessCountPeriod,
-                                    String start, String end, boolean csv) {
+                                    String start, String end, String yopInterval, boolean csv) {
     return getReqsByDateOfUse(pool, isJournal, includeOA, agreementId,
-        accessCountPeriod, start, end)
+        accessCountPeriod, start, end, yopInterval)
         .map(json -> {
           if (!csv) {
             return json.encodePrettily();
@@ -1610,10 +1625,11 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
     String accessCountPeriod = ctx.request().params().get("accessCountPeriod");
     String start = ctx.request().params().get("startDate");
     String end = ctx.request().params().get("endDate");
+    String yopInterval = ctx.request().params().get("yopInterval");
     boolean includeOA = "true".equalsIgnoreCase(ctx.request().params().get("includeOA"));
 
     return getReqsByDateOfUse(pool, isJournal, includeOA, agreementId,
-        accessCountPeriod, start, end, csv)
+        accessCountPeriod, start, end, yopInterval, csv)
         .map(res -> {
           ctx.response().setStatusCode(200);
           ctx.response().putHeader("Content-Type", csv ? "text/csv" : "application/json");
@@ -1690,20 +1706,7 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
             pubYears.forEach(year -> {
               tuple.addLocalDate(year);
               tuple.addLocalDate(year.plusMonths(pubPeriodsInMonths));
-              String s1 = year.toString();
-              String s2 = year.plusMonths(pubPeriodsInMonths - 1).toString();
-              if (s1.endsWith("-01-01") && s2.endsWith("-12-01")) {
-                s1 = s1.substring(0, 4);
-                s2 = s2.substring(0, 4);
-              } else {
-                s1 = s1.substring(0, 7);
-                s2 = s2.substring(0, 7);
-              }
-              if (s1.equals(s2)) {
-                pubYearStrings.add(s1);
-              } else {
-                pubYearStrings.add(s1 + "-" + s2);
-              }
+              pubYearStrings.add(pubPeriodToString(year, pubPeriodsInMonths));
             });
           }
           LocalDate date = usePeriods.startDate;

--- a/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
+++ b/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
@@ -1475,19 +1475,6 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
     sql.append(" WHERE agreementId = $1::uuid").append(limitJournal(isJournal));
   }
 
-  static String pubPeriodToString(LocalDate date, int periodMonth) {
-    String s1 = date.toString();
-    String s2 = date.plusMonths(periodMonth - 1).toString();
-    if (s1.endsWith("-01-01") && s2.endsWith("-12-01")) {
-      s1 = s1.substring(0, 4);
-      s2 = s2.substring(0, 4);
-    } else {
-      s1 = s1.substring(0, 7);
-      s2 = s2.substring(0, 7);
-    }
-    return s1.equals(s2) ? s1 : s1 + "-" + s2;
-  }
-
   Future<JsonObject> getReqsByDateOfUse(TenantPgPool pool,
                                         Boolean isJournal, boolean includeOA, String agreementId,
                                         String accessCountPeriod, String start, String end,
@@ -1549,7 +1536,7 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
               long accessCountTotal = 0L;
               boolean unique = "Unique_Item_Requests".equals(row.getString("metrictype"));
               JsonArray accessCountByPeriod = new JsonArray();
-              String publicationPeriod = pubPeriodToString(row.getLocalDate("publicationdate"),
+              String publicationPeriod = Periods.periodLabel(row.getLocalDate("publicationdate"),
                   pubPeriodsInMonths);
               for (int i = 0; i < usePeriods.size(); i++) {
                 Long l = row.getLong(columnsToSkip + i);
@@ -1706,7 +1693,7 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
             pubYears.forEach(year -> {
               tuple.addLocalDate(year);
               tuple.addLocalDate(year.plusMonths(pubPeriodsInMonths));
-              pubYearStrings.add(pubPeriodToString(year, pubPeriodsInMonths));
+              pubYearStrings.add(Periods.periodLabel(year, pubPeriodsInMonths));
             });
           }
           LocalDate date = usePeriods.startDate;

--- a/src/main/java/org/folio/eusage/reports/api/Periods.java
+++ b/src/main/java/org/folio/eusage/reports/api/Periods.java
@@ -74,9 +74,12 @@ public class Periods {
   }
 
   /**
-   * Label like "2021" or "2020 - 2024" or "2021-05" or "2021-04 - 2021-06".
+   * Return period label for period range date to date+months.
+   * @param date from date
+   * @param periodInMonths plus amount in month
+   * @return label in formats such as YYYY, YYYY-MM, YYYY - YYYY, YYYY-MM - YYYY-MM
    */
-  public String periodLabel(LocalDate date) {
+  public static String periodLabel(LocalDate date, int periodInMonths) {
     String startStr = date.toString();
     if (periodInMonths == 1) {
       return startStr.substring(0, startStr.length() - 3);
@@ -92,6 +95,13 @@ public class Periods {
     String endStr = date.plusMonths(periodInMonths - 1L).toString();
     return startStr.substring(0, startStr.length() - 3) + " - "
         + endStr.subSequence(0, endStr.length() - 3);
+  }
+
+  /**
+   * Label like "2021" or "2020 - 2024" or "2021-05" or "2021-04 - 2021-06".
+   */
+  public String periodLabel(LocalDate date) {
+    return periodLabel(date, periodInMonths);
   }
 
   int getMonths() {

--- a/src/main/resources/openapi/eusage-reports-1.0.yaml
+++ b/src/main/resources/openapi/eusage-reports-1.0.yaml
@@ -190,6 +190,7 @@ paths:
       - $ref: parameters/end-date.yaml
       - $ref: parameters/format.yaml
       - $ref: parameters/include-oa.yaml
+      - $ref: parameters/yop-interval.yaml
     get:
       description: Return requests by date of use; this is like use over time but additionally groups by publication year.
       operationId: getReqsByDateOfUse

--- a/src/main/resources/openapi/parameters/yop-interval.yaml
+++ b/src/main/resources/openapi/parameters/yop-interval.yaml
@@ -1,0 +1,9 @@
+in: query
+name: yopInterval
+description: a number of months or years for grouping publication dates
+required: false
+
+schema:
+  type: string
+  default: auto
+  pattern: ^(\d+[YM])|(auto)$

--- a/src/main/resources/openapi/schemas/reportRow.json
+++ b/src/main/resources/openapi/schemas/reportRow.json
@@ -22,6 +22,10 @@
       "type": "string",
       "description": "ISBN for instance"
     },
+    "publicationYear": {
+      "type": "string",
+      "description": "Publication year .. or range (eg 2000 for 1Y, or 2000-2001 for 2Y)"
+    },
     "periodOfUse": {
       "type": "string",
       "description": "The usage period of this publication year report row, either one month like 2018-03 or one year like 2018 or a month range like 2018-03 - 2018-05 or a year range like 2018-2019"

--- a/src/test/java/org/folio/eusage/reports/api/EusageReportsApiTest.java
+++ b/src/test/java/org/folio/eusage/reports/api/EusageReportsApiTest.java
@@ -530,7 +530,7 @@ public class EusageReportsApiTest {
 
   @Test
   public void reqsByDateOfUseJournal(TestContext context) {
-    new EusageReportsApi().getReqsByDateOfUse(pool, true, true, a2, null, "2020-05", "2020-06")
+    new EusageReportsApi().getReqsByDateOfUse(pool, true, true, a2, null, "2020-05", "2020-06", null)
         .onComplete(context.asyncAssertSuccess(json -> {
           assertThat(json.getLong("totalItemRequestsTotal"), is(42L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(21L));
@@ -552,7 +552,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 21")
                   .put("printISSN", "2121-1111")
                   .put("onlineISSN", null)
-                  .put("publicationYear", 2010)
+                  .put("publicationYear", "2010")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 40L)
@@ -563,7 +563,7 @@ public class EusageReportsApiTest {
 
   @Test
   public void reqsByDateOfUseBook(TestContext context) {
-    new EusageReportsApi().getReqsByDateOfUse(pool, false, true, a2, null, "2020-05", "2020-06")
+    new EusageReportsApi().getReqsByDateOfUse(pool, false, true, a2, null, "2020-05", "2020-06", null)
         .onComplete(context.asyncAssertSuccess(json -> {
           assertThat(json.getLong("totalItemRequestsTotal"), is(42L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(21L));
@@ -575,7 +575,7 @@ public class EusageReportsApiTest {
                   .put("kbId", "31000000-0000-4000-8000-000000000000")
                   .put("title", "Title 31")
                   .put("ISBN", "3131313131")
-                  .put("publicationYear", 2010)
+                  .put("publicationYear", "2010")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 40)
@@ -586,7 +586,7 @@ public class EusageReportsApiTest {
 
   @Test
   public void reqsByDateOfUseBookNoOA(TestContext context) {
-    new EusageReportsApi().getReqsByDateOfUse(pool, false, false, a2, null, "2020-05", "2020-06")
+    new EusageReportsApi().getReqsByDateOfUse(pool, false, false, a2, null, "2020-05", "2020-06", null)
         .onComplete(context.asyncAssertSuccess(json -> {
           assertThat(json.getLong("totalItemRequestsTotal"), is(40L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(20L));
@@ -598,7 +598,7 @@ public class EusageReportsApiTest {
                   .put("kbId", "31000000-0000-4000-8000-000000000000")
                   .put("title", "Title 31")
                   .put("ISBN", "3131313131")
-                  .put("publicationYear", 2010)
+                  .put("publicationYear", "2010")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 40)
@@ -609,7 +609,7 @@ public class EusageReportsApiTest {
 
   @Test
   public void reqsByDateOfUseAll(TestContext context) {
-    new EusageReportsApi().getReqsByDateOfUse(pool, null, true, a2, null, "2020-05", "2020-06")
+    new EusageReportsApi().getReqsByDateOfUse(pool, null, true, a2, null, "2020-05", "2020-06", null)
         .onComplete(context.asyncAssertSuccess(json -> {
           assertThat(json.getLong("totalItemRequestsTotal"), is(84L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(42L));
@@ -621,7 +621,7 @@ public class EusageReportsApiTest {
 
   @Test
   public void reqsByDateOfUseNoPubYears(TestContext context) {
-    new EusageReportsApi().getReqsByDateOfUse(pool, true, true, a1, null, "2005-02", "2005-06")
+    new EusageReportsApi().getReqsByDateOfUse(pool, true, true, a1, null, "2005-02", "2005-06", "auto")
         .onComplete(context.asyncAssertSuccess(json -> {
           assertThat(json.getLong("totalItemRequestsTotal"), is(0L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(0L));
@@ -630,7 +630,7 @@ public class EusageReportsApiTest {
 
   @Test
   public void reqsByDateOfUse63(TestContext context) {
-    new EusageReportsApi().getReqsByDateOfUse(pool, true, true, a1, null, "2020-02", "2020-06")
+    new EusageReportsApi().getReqsByDateOfUse(pool, true, true, a1, null, "2020-02", "2020-06", null)
         .onComplete(context.asyncAssertSuccess(json -> {
           assertThat(json.getLong("totalItemRequestsTotal"), is(99L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(59L));
@@ -658,7 +658,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 11")
                   .put("printISSN", "1111-1111")
                   .put("onlineISSN", "1111-2222")
-                  .put("publicationYear", 1999)
+                  .put("publicationYear", "1999")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 5)
@@ -670,7 +670,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 11")
                   .put("printISSN", "1111-1111")
                   .put("onlineISSN", "1111-2222")
-                  .put("publicationYear", 1999)
+                  .put("publicationYear", "1999")
                   .put("accessType", "Controlled")
                   .put("metricType", "Unique_Item_Requests")
                   .put("accessCountTotal", 3)
@@ -682,7 +682,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 11")
                   .put("printISSN", "1111-1111")
                   .put("onlineISSN", "1111-2222")
-                  .put("publicationYear", 2000)
+                  .put("publicationYear", "2000")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 44)
@@ -694,7 +694,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 11")
                   .put("printISSN", "1111-1111")
                   .put("onlineISSN", "1111-2222")
-                  .put("publicationYear", 2000)
+                  .put("publicationYear", "2000")
                   .put("accessType", "Controlled")
                   .put("metricType", "Unique_Item_Requests")
                   .put("accessCountTotal", 16)
@@ -706,7 +706,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 12")
                   .put("printISSN", "1212-1111")
                   .put("onlineISSN", "1212-2222")
-                  .put("publicationYear", 2010)
+                  .put("publicationYear", "2010")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 50)
@@ -718,7 +718,7 @@ public class EusageReportsApiTest {
                   .put("title", "Title 12")
                   .put("printISSN", "1212-1111")
                   .put("onlineISSN", "1212-2222")
-                  .put("publicationYear", 2010)
+                  .put("publicationYear", "2010")
                   .put("accessType", "Controlled")
                   .put("metricType", "Unique_Item_Requests")
                   .put("accessCountTotal", 40)
@@ -792,6 +792,49 @@ public class EusageReportsApiTest {
   }
 
   @Test
+  public void reqsByDateOfUseYopInterval2Y(TestContext context) {
+    new EusageReportsApi().getReqsByDateOfUse(pool, null, true, a1, null, "2020-02", "2020-06", "2Y")
+        .onComplete(context.asyncAssertSuccess(json -> {
+          System.out.println(json.encodePrettily());
+          assertThat(json.getLong("totalItemRequestsTotal"), is(99L));
+          assertThat(json.getLong("uniqueItemRequestsTotal"), is(59L));
+          assertThat((Long []) json.getValue("totalItemRequestsByPeriod"), is(arrayContaining(null, 14L, 22L, 34L, 29L)));
+          assertThat((Long []) json.getValue("uniqueItemRequestsByPeriod"), is(arrayContaining(null, 12L, 20L, 18L, 9L)));
+          assertThat(json.getJsonArray("totalRequestsPublicationYearsByPeriod").encodePrettily(),
+              is(new JsonArray()
+                  .add(new JsonObject())
+                  .add(new JsonObject().put("1998-1999", 2).put("2010-2011", 12))
+                  .add(new JsonObject().put("1998-1999", 3).put("2000-2001", 3).put("2010-2011", 16).put("2010-2011", 16))
+                  .add(new JsonObject().put("2000-2001", 12).put("2010-2011", 22))
+                  .add(new JsonObject().put("2000-2001", 29))
+                  .encodePrettily()));
+          assertThat(json.getJsonArray("uniqueRequestsPublicationYearsByPeriod").encodePrettily(),
+              is(new JsonArray()
+                  .add(new JsonObject())
+                  .add(new JsonObject().put("1998-1999", 1).put("2010-2011", 11))
+                  .add(new JsonObject().put("1998-1999", 2).put("2000-2001", 3).put("2010-2011", 16).put("2010-2011", 15))
+                  .add(new JsonObject().put("2000-2001", 4).put("2010-2011", 14))
+                  .add(new JsonObject().put("2000-2001", 9))
+                  .encodePrettily()));
+          assertThat(json.getJsonArray("items").size(), is(6));
+          assertThat(json.getJsonArray("items").getJsonObject(0).encodePrettily(),
+              is(new JsonObject()
+                  .put("kbId", "11000000-0000-4000-8000-000000000000")
+                  .put("title", "Title 11")
+                  .put("printISSN", "1111-1111")
+                  .put("onlineISSN", "1111-2222")
+                  .put("ISBN", null)
+                  .put("publicationYear", "1998-1999")
+                  .put("accessType", "Controlled")
+                  .put("metricType", "Total_Item_Requests")
+                  .put("accessCountTotal", 5)
+                  .put("accessCountsByPeriod", new JsonArray("[ null, 2, 3, null, null ]"))
+                  .encodePrettily()));
+
+        }));
+  }
+
+  @Test
   public void reqsByDateOfUseWithRoutingContext(TestContext context) {
     RoutingContext routingContext = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
     when(routingContext.request().getHeader("X-Okapi-Tenant")).thenReturn(tenant);
@@ -814,7 +857,7 @@ public class EusageReportsApiTest {
               .put("title", "Title 21")
               .put("printISSN", "2121-1111")
               .put("onlineISSN", null)
-              .put("publicationYear", 2010)
+              .put("publicationYear", "2010")
               .put("accessType", "Controlled")
               .put("metricType", "Total_Item_Requests")
               .put("accessCountTotal", 40)

--- a/src/test/java/org/folio/eusage/reports/api/EusageReportsApiTest.java
+++ b/src/test/java/org/folio/eusage/reports/api/EusageReportsApiTest.java
@@ -803,18 +803,18 @@ public class EusageReportsApiTest {
           assertThat(json.getJsonArray("totalRequestsPublicationYearsByPeriod").encodePrettily(),
               is(new JsonArray()
                   .add(new JsonObject())
-                  .add(new JsonObject().put("1998-1999", 2).put("2010-2011", 12))
-                  .add(new JsonObject().put("1998-1999", 3).put("2000-2001", 3).put("2010-2011", 16).put("2010-2011", 16))
-                  .add(new JsonObject().put("2000-2001", 12).put("2010-2011", 22))
-                  .add(new JsonObject().put("2000-2001", 29))
+                  .add(new JsonObject().put("1998 - 1999", 2).put("2010 - 2011", 12))
+                  .add(new JsonObject().put("1998 - 1999", 3).put("2000 - 2001", 3).put("2010 - 2011", 16).put("2010 - 2011", 16))
+                  .add(new JsonObject().put("2000 - 2001", 12).put("2010 - 2011", 22))
+                  .add(new JsonObject().put("2000 - 2001", 29))
                   .encodePrettily()));
           assertThat(json.getJsonArray("uniqueRequestsPublicationYearsByPeriod").encodePrettily(),
               is(new JsonArray()
                   .add(new JsonObject())
-                  .add(new JsonObject().put("1998-1999", 1).put("2010-2011", 11))
-                  .add(new JsonObject().put("1998-1999", 2).put("2000-2001", 3).put("2010-2011", 16).put("2010-2011", 15))
-                  .add(new JsonObject().put("2000-2001", 4).put("2010-2011", 14))
-                  .add(new JsonObject().put("2000-2001", 9))
+                  .add(new JsonObject().put("1998 - 1999", 1).put("2010 - 2011", 11))
+                  .add(new JsonObject().put("1998 - 1999", 2).put("2000 - 2001", 3).put("2010 - 2011", 16).put("2010 - 2011", 15))
+                  .add(new JsonObject().put("2000 - 2001", 4).put("2010 - 2011", 14))
+                  .add(new JsonObject().put("2000 - 2001", 9))
                   .encodePrettily()));
           assertThat(json.getJsonArray("items").size(), is(6));
           assertThat(json.getJsonArray("items").getJsonObject(0).encodePrettily(),
@@ -824,7 +824,7 @@ public class EusageReportsApiTest {
                   .put("printISSN", "1111-1111")
                   .put("onlineISSN", "1111-2222")
                   .put("ISBN", null)
-                  .put("publicationYear", "1998-1999")
+                  .put("publicationYear", "1998 - 1999")
                   .put("accessType", "Controlled")
                   .put("metricType", "Total_Item_Requests")
                   .put("accessCountTotal", 5)
@@ -970,7 +970,7 @@ public class EusageReportsApiTest {
           verify(routingContext.response()).end(body.capture());
           JsonObject json = new JsonObject(body.getValue());
           assertThat((List<?>) json.getJsonArray("accessCountPeriods").getList(),
-              contains("1998-1999", "2000-2001", "2010-2011"));
+              contains("1998 - 1999", "2000 - 2001", "2010 - 2011"));
           assertThat(json.getLong("totalItemRequestsTotal"), is(99L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(59L));
           assertThat(json.getJsonArray("totalItemRequestsByPeriod"), contains(5, 44, 50));
@@ -994,7 +994,7 @@ public class EusageReportsApiTest {
           verify(routingContext.response()).end(body.capture());
           JsonObject json = new JsonObject(body.getValue());
           assertThat((List<?>) json.getJsonArray("accessCountPeriods").getList(),
-              contains("1999-01-1999-03", "2000-01-2000-03", "2010-01-2010-03"));
+              contains("1999-01 - 1999-03", "2000-01 - 2000-03", "2010-01 - 2010-03"));
           assertThat(json.getLong("totalItemRequestsTotal"), is(99L));
           assertThat(json.getLong("uniqueItemRequestsTotal"), is(59L));
           assertThat(json.getJsonArray("totalItemRequestsByPeriod"), contains(5, 44, 50));


### PR DESCRIPTION
Note that publicationYear in items is now a string rather than
integer, because the publicationYear may be a period due.