### PR TITLE
Support erm 5.0 interface MODEUR-91

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -117,7 +117,7 @@
   "requires" : [
     {
       "id" : "erm",
-      "version" : "4.1"
+      "version" : "4.1 5.0"
     },
     {
       "id" : "usage-data-providers",


### PR DESCRIPTION
Both 4.1 and 5.0 supported as mod-eusage-reports do not ever
inspect the "orgs" which changed definition.