### PR TITLE
Fix costPerTotalRequest for packages MODEUR-99

### DIFF
--- a/src/main/java/org/folio/eusage/reports/api/CostPerUse.java
+++ b/src/main/java/org/folio/eusage/reports/api/CostPerUse.java
@@ -152,17 +152,18 @@ public class CostPerUse {
       Number amountPaid = row.getNumeric("invoicedcost");
       if (amountPaid != null) {
         Double amount = allPeriodsMonths * amountPaid.doubleValue() / subscriptionMonths;
-        item.put("amountPaid", formatCost(amount / titlesDivide));
+        Double amountTitle = amount / titlesDivide;
+        item.put("amountPaid", formatCost(amountTitle));
         paidByPeriodMap.get(idx).putIfAbsent(paidId, thisPeriodMonths * amountPaid.doubleValue()
             / subscriptionMonths);
         amountPaidTotalMap.putIfAbsent(paidId, amount);
         Long totalItemRequests = item.getLong("totalItemRequests");
         if (totalItemRequests != null && totalItemRequests > 0L) {
-          item.put("costPerTotalRequest", formatCost(amount / totalItemRequests));
+          item.put("costPerTotalRequest", formatCost(amountTitle / totalItemRequests));
         }
         Long uniqueItemRequests = item.getLong("uniqueItemRequests");
         if (uniqueItemRequests != null && uniqueItemRequests > 0L) {
-          item.put("costPerUniqueRequest", formatCost(amount / uniqueItemRequests));
+          item.put("costPerUniqueRequest", formatCost(amountTitle / uniqueItemRequests));
         }
       }
       JsonArray poLineIDs = item.getJsonArray("poLineIDs");

--- a/src/test/java/org/folio/eusage/reports/api/EusageReportsApiTest.java
+++ b/src/test/java/org/folio/eusage/reports/api/EusageReportsApiTest.java
@@ -1262,7 +1262,10 @@ assertThat(json.getJsonArray("items").size(), is(4));
           assertThat(items.size(), is(2));
           assertThat(items.getJsonObject(0).getBoolean("derivedTitle"), is(true));
           assertThat(items.getJsonObject(1).getBoolean("derivedTitle"), is(true));
-          System.out.println(json.encodePrettily());
+          assertThat(items.getJsonObject(0).getDouble("costPerTotalRequest"), is(1.42));
+          assertThat(items.getJsonObject(1).getDouble("costPerTotalRequest"), is(2.64));
+          assertThat(items.getJsonObject(0).getDouble("costPerUniqueRequest"), is(4.47));
+          assertThat(items.getJsonObject(1).getDouble("costPerUniqueRequest"), is(4.15));
         }));
   }
 


### PR DESCRIPTION
And also costPerUniqueRequest. Problem: the cost must be divided
by the titles in a package.