### PR TITLE
facets=status, counter parse returns no titles MODEUR-30

### DIFF
--- a/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
+++ b/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
@@ -252,7 +252,19 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
     final TenantPgPool pool = TenantPgPool.pool(vertx, tenant);
     final String distinctCount = titleEntriesTable(pool) + ".id";
     final String query = stringOrNull(params.queryParameter("query"));
+    RequestParameter facetsParameter = params.queryParameter("facets");
+    String [] facetsList = facetsParameter == null
+        ? new String[0]
+        : facetsParameter.getString().split(",");
 
+    boolean includeStatusFacet = false;
+    for (String name : facetsList) {
+      if ("status".equals(name)) {
+        includeStatusFacet = true;
+      } else {
+        throw new IllegalArgumentException("Unsupported facet: " + name);
+      }
+    }
     List<String> fromList = new ArrayList<>(); // main query and facet queries
     pgCqlQuery.parse(query);
     String orderByFields = pgCqlQuery.getOrderByFields();
@@ -263,22 +275,22 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
     final String orderByClause = pgCqlQuery.getOrderByClause();
     fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
 
-    // add query for each facet
-    pgCqlQuery.parse(query, "kbTitleId = \"\"");
-    fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
+    List<String[]> statusValues = new ArrayList<>();
+    if (includeStatusFacet) {
+      // add query for each status facet
+      pgCqlQuery.parse(query, "kbTitleId = \"\"");
+      fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
+      statusValues.add(new String[]{"status", "matched"});
 
-    pgCqlQuery.parse(query, "kbTitleId <> \"\" AND kbManualMatch = false");
-    fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
+      pgCqlQuery.parse(query, "kbTitleId <> \"\" AND kbManualMatch = false");
+      fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
+      statusValues.add(new String[]{"status", "unmactched"});
 
-    pgCqlQuery.parse(query, "kbTitleId <> \"\" AND kbManualMatch = true");
-    fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
-
-    List<String[]> facets = new ArrayList<>(List.of(
-        new String [] {"status", "matched"},
-        new String [] {"status", "unmatched"},
-        new String [] {"status", "ignored"})
-    );
-    return streamResult(ctx, pool, distinctMain, distinctCount, fromList, facets,
+      pgCqlQuery.parse(query, "kbTitleId <> \"\" AND kbManualMatch = true");
+      fromList.add(getFromTitleDataForeignKey(pgCqlQuery, counterReportId, providerId, pool));
+      statusValues.add(new String[]{"status", "ignored"});
+    }
+    return streamResult(ctx, pool, distinctMain, distinctCount, fromList, statusValues,
         orderByClause,"titles",
         row -> new JsonObject()
             .put("id", row.getUUID("id"))
@@ -432,7 +444,10 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
         .onFailure(x -> log.error(x.getMessage(), x))
         .compose(x -> {
           if (Boolean.TRUE.equals(x)) {
-            return getReportTitles(vertx, ctx);
+            ctx.response().setStatusCode(200);
+            ctx.response().putHeader("Content-Type", "application/json");
+            ctx.response().end("{}");
+            return Future.succeededFuture();
           }
           failHandler(404, ctx, "Not Found");
           return Future.succeededFuture();

--- a/src/main/resources/openapi/eusage-reports-1.0.yaml
+++ b/src/main/resources/openapi/eusage-reports-1.0.yaml
@@ -8,9 +8,10 @@ paths:
       - $ref: headers/okapi-tenant.yaml
       - $ref: headers/okapi-token.yaml
       - $ref: headers/okapi-url.yaml
-      - $ref: parameters/offset.yaml
+      - $ref: parameters/facets.yaml
       - $ref: parameters/limit.yaml
       - $ref: parameters/query.yaml
+      - $ref: parameters/offset.yaml
       - in: query
         name: counterReportId
         required: false
@@ -99,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: schemas/reportTitles.json
+                $ref: schemas/fromCounterResponse.json
         "400":
           $ref: "#/components/responses/trait_400"
         "404":

--- a/src/main/resources/openapi/parameters/facets.yaml
+++ b/src/main/resources/openapi/parameters/facets.yaml
@@ -1,0 +1,6 @@
+in: query
+name: facets
+description: facet names. Each facet is separted by comma.
+required: false
+schema:
+  type: string

--- a/src/main/resources/openapi/schemas/fromCounterResponse.json
+++ b/src/main/resources/openapi/schemas/fromCounterResponse.json
@@ -1,0 +1,5 @@
+{
+  "description": "Parse counter report response",
+  "type": "object",
+  "additionalProperties": false
+}


### PR DESCRIPTION
New query parameter facets supported. At this stage - for
GET /eusage-reports/report-titles it can only take value "status" in
which case titles status facets are returned (matched, unmatched,
ignored). If facets parameter is omitted, no facets are returned.
POST /eusage-reports/report-titles/from-counter no longer returns
titles. The status is the same for successful parse (200), but
the content is an empty object at the momemt.