### PR TITLE
Timings for some reports, pg explain MODEUR-118

### DIFF
--- a/src/main/java/org/folio/tlib/postgres/TenantPgPool.java
+++ b/src/main/java/org/folio/tlib/postgres/TenantPgPool.java
@@ -4,6 +4,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import org.folio.tlib.postgres.impl.TenantPgPoolImpl;
@@ -24,6 +27,8 @@ public interface TenantPgPool extends PgPool {
   }
 
   Future<Void> execute(List<String> queries);
+
+  Future<RowSet<Row>> execute(String sql, Tuple tuple);
 
   String getSchema();
 

--- a/src/main/resources/openapi/schemas/report.json
+++ b/src/main/resources/openapi/schemas/report.json
@@ -78,6 +78,10 @@
         "type": "object",
         "$ref": "reportRow.json"
       }
+    },
+    "execution": {
+      "description": "Information about execution, such as various timings",
+      "type": "object"
     }
   },
   "additionalProperties": false

--- a/src/main/resources/openapi/schemas/reportCost.json
+++ b/src/main/resources/openapi/schemas/reportCost.json
@@ -72,6 +72,10 @@
         "type": "number",
         "nullable": true
       }
+    },
+    "execution": {
+      "description": "Information about execution, such as various timings",
+      "type": "object"
     }
   },
   "additionalProperties": false

--- a/src/test/java/org/folio/tlib/postgres/TenantPgPoolTest.java
+++ b/src/test/java/org/folio/tlib/postgres/TenantPgPoolTest.java
@@ -30,7 +30,7 @@ import org.testcontainers.utility.MountableFile;
 
 @RunWith(VertxUnitRunner.class)
 public class TenantPgPoolTest {
-  private final static Logger log = LogManager.getLogger("MainVerticleTest");
+  private final static Logger log = LogManager.getLogger(TenantPgPoolTest.class);
 
   @ClassRule
   public static PostgreSQLContainer<?> postgresSQLContainer = TenantPgPoolContainer.create();
@@ -129,6 +129,24 @@ public class TenantPgPoolTest {
         .preparedQuery("SELECT * FROM pg_database WHERE datname=$1")
         .execute(Tuple.of("postgres")))
     .onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void executeOk(TestContext context) {
+    withPool(pool -> pool
+        .execute("SELECT * FROM pg_database WHERE datname=$1", Tuple.of("postgres")))
+        .onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void executeAnalyze(TestContext context) {
+    vertx.getOrCreateContext().config().put("explain_analyze", Boolean.TRUE);
+    withPool(pool -> pool
+        .execute("SELECT * FROM pg_database WHERE datname=$1", Tuple.of("postgres")))
+        .onComplete(x -> {
+          vertx.getOrCreateContext().config().remove("explain_analyze");
+          context.assertTrue(x.succeeded());
+        });
   }
 
   @Test


### PR DESCRIPTION
Vert.x property config_explain makes pool.execute perform EXPLAIN
ANALYZE query.

Log timings for useOverTime and costPerUse and put it in JSON response.

Add indices for kbTitleName, kbTitleId, kbPackageId.