### PR TITLE
Support order-lines 3.0 MODEUR-125

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -142,7 +142,7 @@
     },
     {
       "id" : "order-lines",
-      "version" : "2.0"
+      "version" : "2.0 3.0"
     },
     {
       "id" : "invoice-storage.invoice-lines",

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.1.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-        </dependency>
-       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>4.1.65.Final</version>
+        <version>4.2.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -80,7 +73,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>3.0.7</version>
+        <version>4.4.0</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/MODEUR-125

CompositePoLine#acquisitionMethod changed for mod-orders(storage)
and that's not used, so mod-eusage-reports should support major
versions.