### PR TITLE
Update to folio-vertx-lib 1.0.1 MODEUR-130

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.4</version>
+        <version>4.2.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -53,22 +53,22 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>4.12.0</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-testing</artifactId>
-        <version>4.12.0</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>vertx-lib</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>vertx-lib-pg-testing</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Fixes tenant id including _ is rejected. Upgrade to Vert.x 4.2.5,
Okapi 4.13.0.