### PR TITLE
FOLIO-3678 Use GitHub Workflows api-lint and api-schema-lint

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -1,0 +1,65 @@
+name: api-lint
+
+# https://dev.folio.org/guides/api-lint/
+
+# API_TYPES: string: The space-separated list of types to consider.
+# One or more of 'RAML OAS'.
+# e.g. 'OAS'
+#
+# API_DIRECTORIES: string: The space-separated list of directories to search
+# for API description files.
+# e.g. 'src/main/resources/openapi'
+# NOTE: -- Also add each separate path to each of the "on: paths:" sections.
+# e.g. 'src/main/resources/openapi/**'
+#
+# API_EXCLUDES: string: The space-separated list of directories and files
+# to exclude from traversal, in addition to the default exclusions.
+# e.g. ''
+#
+# API_WARNINGS: boolean: Whether to cause Warnings to be displayed,
+# and to fail the workflow.
+# e.g. false
+
+env:
+  API_TYPES: 'OAS'
+  API_DIRECTORIES: 'src/main/resources/openapi'
+  API_EXCLUDES: ''
+  API_WARNINGS: false
+
+on:
+  push:
+    paths:
+      - 'src/main/resources/openapi/**'
+  pull_request:
+    paths:
+      - 'src/main/resources/openapi/**'
+
+jobs:
+  api-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Prepare folio-tools
+        run: |
+          git clone https://github.com/folio-org/folio-tools
+          cd folio-tools/api-lint \
+            && yarn install \
+            && pip3 install -r requirements.txt
+      - name: Configure default options
+        run: |
+          echo "OPTION_WARNINGS=''" >> $GITHUB_ENV
+      - name: Configure option warnings
+        if: ${{ env.API_WARNINGS == 'true' }}
+        run: |
+          echo "OPTION_WARNINGS=--warnings" >> $GITHUB_ENV
+      - name: Do api-lint
+        run: |
+          python3 folio-tools/api-lint/api_lint.py \
+            --loglevel info \
+            --types ${{ env.API_TYPES }} \
+            --directories ${{ env.API_DIRECTORIES }} \
+            --excludes ${{ env.API_EXCLUDES }} \
+            ${{ env.OPTION_WARNINGS }}

--- a/.github/workflows/api-schema-lint.yml
+++ b/.github/workflows/api-schema-lint.yml
@@ -1,0 +1,46 @@
+name: api-schema-lint
+
+# https://dev.folio.org/guides/describe-schema/
+
+# API_DIRECTORIES: string: The space-separated list of directories to search
+# for JSON Schema files.
+# e.g. 'src/main/resources/openapi'
+# NOTE: -- Also add each separate path to each of the "on: paths:" sections.
+# e.g. 'src/main/resources/openapi/**'
+#
+# API_EXCLUDES: string: The space-separated list of directories and files
+# to exclude from traversal, in addition to the default exclusions.
+# e.g. ''
+
+env:
+  API_DIRECTORIES: 'src/main/resources/openapi'
+  API_EXCLUDES: ''
+
+on:
+  push:
+    paths:
+      - 'src/main/resources/openapi/**'
+  pull_request:
+    paths:
+      - 'src/main/resources/openapi/**'
+
+jobs:
+  api-schema-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Prepare folio-tools
+        run: |
+          git clone https://github.com/folio-org/folio-tools
+          cd folio-tools/api-schema-lint \
+            && yarn install \
+            && pip3 install -r requirements.txt
+      - name: Do api-schema-lint
+        run: |
+          python3 folio-tools/api-schema-lint/api_schema_lint.py \
+            --loglevel info \
+            --directories ${{ env.API_DIRECTORIES }} \
+            --excludes ${{ env.API_EXCLUDES }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ buildMvn {
   mvnDeploy = true
   buildNode =  'jenkins-agent-java11'
 
-  doApiLint = true
   doApiDoc = true
   apiTypes = 'OAS'
   apiDirectories = 'src/main/resources/openapi'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-eusage-reports
 
-Copyright (C) 2021-2022 The Open Library Foundation
+Copyright (C) 2021-2023 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/src/main/resources/openapi/eusage-reports-1.0.yaml
+++ b/src/main/resources/openapi/eusage-reports-1.0.yaml
@@ -371,3 +371,4 @@ components:
     errors:
       $ref: schemas/errors.json
 
+


### PR DESCRIPTION
[FOLIO-3678](https://issues.folio.org/browse/FOLIO-3678)

Use GitHub Workflows for api-lint and api-schema-lint
(instead of Jenkins-operated CI stages).

https://dev.folio.org/guides/api-lint/
https://dev.folio.org/guides/describe-schema/