### PR TITLE
ERM-2641: Upgrade to Grails 5 (including Hibernate 5.6.x) for Poppy

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -118,7 +118,7 @@
   "requires" : [
     {
       "id" : "erm",
-      "version" : "4.1 5.0"
+      "version" : "4.1 5.0 6.0"
     },
     {
       "id" : "usage-data-providers",


### PR DESCRIPTION
build: erm 6.0

Added okapi interface dependency on new erm interface 6.0

refs ERM-2641