### PR TITLE
MODEUR-150-update-fetch-erm-titles

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -118,7 +118,7 @@
   "requires" : [
     {
       "id" : "erm",
-      "version" : "4.1 5.0 6.0"
+      "version" : "6.0"
     },
     {
       "id" : "usage-data-providers",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-eusage-reports</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>eUsage Reports</name>

--- a/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
+++ b/src/main/java/org/folio/eusage/reports/api/EusageReportsApi.java
@@ -492,11 +492,10 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
 
   Future<Tuple> ermTitleLookup(RoutingContext ctx, String identifier, String type) {
     // assuming identifier only has unreserved characters
-    // TODO .. this will match any type of identifier.
     // what if there's more than one hit?
-    String uri = "/erm/resource?"
-        + "match=identifiers.identifier.value&term=" + identifier
-        + "&filters=identifiers.identifier.ns.value%3D" + type;
+    String uri = "/erm/titles?"
+        + "filters=(identifiers.identifier.ns.value%3D%3D" + type
+        + "%26%26identifiers.identifier.value%3D%3D" + identifier + ")";
     return getRequestSend(ctx, uri)
         .map(res -> {
           JsonArray ar = res.bodyAsJsonArray();
@@ -505,7 +504,7 @@ public class EusageReportsApi implements RouterCreator, TenantInitHooks {
   }
 
   Future<Tuple> ermTitleLookup(RoutingContext ctx, UUID id) {
-    String uri = "/erm/resource/" + id;
+    String uri = "/erm/titles/" + id;
     return getRequestSend(ctx, uri)
         .map(res -> parseErmTitle(res.bodyAsJsonObject()));
   }

--- a/src/test/java/org/folio/eusage/reports/MainVerticleTest.java
+++ b/src/test/java/org/folio/eusage/reports/MainVerticleTest.java
@@ -320,10 +320,13 @@ public class MainVerticleTest {
     }
     return res;
   }
-  static void getErmResource(RoutingContext ctx) {
+
+  static void getErmTitle(RoutingContext ctx) {
     ctx.response().setChunked(true);
     ctx.response().putHeader("Content-Type", "application/json");
-    String term = ctx.request().getParam("term");
+    String filtersParam = ctx.request().getParam("filters");
+    String term =
+        filtersParam.substring(filtersParam.lastIndexOf("==") + 2, filtersParam.lastIndexOf(")"));
     JsonArray ar = new JsonArray();
     UUID kbTitleId;
     switch (term) {
@@ -347,7 +350,7 @@ public class MainVerticleTest {
     ctx.response().end(ar.encode());
   }
 
-  static void getErmResourceId(RoutingContext ctx) {
+  static void getErmTitleId(RoutingContext ctx) {
     String path = ctx.request().path();
     int offset = path.lastIndexOf('/');
     UUID id = UUID.fromString(path.substring(offset + 1));
@@ -710,8 +713,8 @@ public class MainVerticleTest {
     Router router = Router.router(vertx);
     router.getWithRegex("/counter-reports").handler(MainVerticleTest::getCounterReports);
     router.getWithRegex("/counter-reports/[-0-9a-z]*").handler(MainVerticleTest::getCounterReport);
-    router.getWithRegex("/erm/resource").handler(MainVerticleTest::getErmResource);
-    router.getWithRegex("/erm/resource/[-0-9a-z]*").handler(MainVerticleTest::getErmResourceId);
+    router.getWithRegex("/erm/titles").handler(MainVerticleTest::getErmTitle);
+    router.getWithRegex("/erm/titles/[-0-9a-z]*").handler(MainVerticleTest::getErmTitleId);
     router.getWithRegex("/erm/resource/[-0-9a-z]*/entitlementOptions").handler(MainVerticleTest::getErmResourceEntitlement);
     router.getWithRegex("/erm/sas/[-0-9a-z]*").handler(MainVerticleTest::getAgreement);
     router.getWithRegex("/erm/entitlements").handler(MainVerticleTest::getEntitlements);

--- a/src/test/java/org/folio/eusage/reports/MainVerticleTest.java
+++ b/src/test/java/org/folio/eusage/reports/MainVerticleTest.java
@@ -360,20 +360,6 @@ public class MainVerticleTest {
     ctx.response().end(getKbTitle(id).encode());
   }
 
-  static void getErmResourceEntitlement(RoutingContext ctx) {
-    ctx.response().setChunked(true);
-    ctx.response().putHeader("Content-Type", "application/json");
-    String term = ctx.request().getParam("term");
-    JsonArray ar = new JsonArray();
-    if ("org.olf.kb.Pkg".equals(term)) {
-      ar.add(new JsonObject()
-          .put("id", UUID.randomUUID())
-          .put("name", "fake kb package name")
-      );
-    }
-    ctx.response().end(ar.encode());
-  }
-
   static void getAgreement(RoutingContext ctx) {
     String path = ctx.request().path();
     int offset = path.lastIndexOf('/');
@@ -715,7 +701,6 @@ public class MainVerticleTest {
     router.getWithRegex("/counter-reports/[-0-9a-z]*").handler(MainVerticleTest::getCounterReport);
     router.getWithRegex("/erm/titles").handler(MainVerticleTest::getErmTitle);
     router.getWithRegex("/erm/titles/[-0-9a-z]*").handler(MainVerticleTest::getErmTitleId);
-    router.getWithRegex("/erm/resource/[-0-9a-z]*/entitlementOptions").handler(MainVerticleTest::getErmResourceEntitlement);
     router.getWithRegex("/erm/sas/[-0-9a-z]*").handler(MainVerticleTest::getAgreement);
     router.getWithRegex("/erm/entitlements").handler(MainVerticleTest::getEntitlements);
     router.getWithRegex("/orders/order-lines/[-0-9a-z]*").handler(MainVerticleTest::getOrderLines);


### PR DESCRIPTION
This PR introduces some changes to the URL and query parameters utilized for fetching titles from erm.
You can find more details in  [MODEUR-150](https://issues.folio.org/browse/MODEUR-150).
The query syntax employed here relies on erm version 6.0 or higher for proper functionality.
As a result, support for versions of erm below 6.0 has been discontinued, necessitating a major version increment.