### PR TITLE
[MODEUR-158] Remove unused required interfaces from module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -121,24 +121,8 @@
       "version" : "6.0 7.0"
     },
     {
-      "id" : "usage-data-providers",
-      "version" : "2.6"
-    },
-    {
-      "id" : "aggregator-settings",
-      "version" : "1.2"
-    },
-    {
       "id" : "counter-reports",
       "version" : "3.1"
-    },
-    {
-      "id" : "custom-reports",
-      "version" : "1.1"
-    },
-    {
-      "id" : "erm-usage-files",
-      "version" : "1.0"
     },
     {
       "id" : "order-lines",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUR-158

```
usage-data-providers 2.6
aggregator-settings 1.2
custom-reports 1.1
erm-usage-files 1.0
```

This PR removes unused interfaces from the module descriptor.
Major version has been increased in prior PRs.