### PR TITLE
[MODORDSTOR-448] Updated order-lines interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -126,7 +126,7 @@
     },
     {
       "id" : "order-lines",
-      "version" : "2.0 3.0"
+      "version" : "3.0 4.0"
     },
     {
       "id" : "invoice-storage.invoice-lines",


### PR DESCRIPTION
## Purpose
[MODORDSTOR-448](https://folio-org.atlassian.net/browse/MODORDSTOR-448) - Make user limit as string field & apply migration

## Approach
Updated the order-lines interface version

## Related PRs
See [acq-models](https://github.com/folio-org/acq-models/pull/519) or [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/476) PRs (there are lots).